### PR TITLE
chore(common): codegen annotations for Metadata

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -37,6 +37,7 @@ components:
       type: object
       maxProperties: 64
       example: {}
+      x-go-type-skip-optional-pointer: true
   parameters:
     MerchantCode:
       name: merchant_code


### PR DESCRIPTION
Resolving this in our APIs that import the common schemas seems quite
complicated, adding it here given we strip the extensions anyway
before the models make their way into the final OpenAPI specs.
